### PR TITLE
feature: add docker image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12.0
+LABEL maintainer ricci.christian@gmail.com
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		git \
+	; \
+	rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/christianricci/task_executor.git
+WORKDIR task_executor
+RUN python setup.py sdist
+RUN pip install dist/task_executor-0.1.tar.gz
+CMD echo "docker run -ti <container_name> python -m task_executor.shell_executor --help"
+CMD tail -f /dev/null

--- a/README.md
+++ b/README.md
@@ -88,3 +88,19 @@ $ PYTHONPATH=<PATH_TO_WORKSPACE>/task_executor/sample.py
 Execution returnCode: [0, 0, 1, 0, 0]
 2023-10-20 21:04:45.486748 -> finished
 ```
+## Run from Docker
+```
+$ git clone https://github.com/christianricci/task_executor.git
+$ cd task_executor
+$ cat Dockerfile
+
+$ docker build .
+$ docker tag <image_id> task-executor:latest # Get the id from the previous cmd output
+$ docker run -d -i --name task_executor task-executor:latest
+
+$ docker exec -ti task_executor python -m task_executor.shell_executor
+$ docker exec -ti task_executor python -m task_executor.shell_executor create_executor_db
+$ docker exec -ti task_executor python -m task_executor.shell_executor add_command my-tag '{"command": ["echo","\"Hello World!!!\""]}'
+$ docker exec -ti task_executor python -m task_executor.shell_executor run_command my-tag 1 1
+$ docker exec -ti task_executor cat /task_executor/shell-executor.debug.log
+```

--- a/task_executor/model/executor_action_db.py
+++ b/task_executor/model/executor_action_db.py
@@ -34,7 +34,7 @@ from .orm import Status, Task, TaskLog
 class ExecutorActionDB:
     def __init__(self, db_file_full_path: str, echo=True):
         self.db_file_full_path = db_file_full_path
-        self.engine = create_engine(f'sqlite:///{self.db_file_full_path}', echo=echo)
+        self.engine = create_engine(f'sqlite:///{self.db_file_full_path}', echo=echo, pool_size=0, max_overflow=-1)
         self.session = sessionmaker(bind=self.engine)
         self.logger = logging.getLogger(__class__.__name__)
 


### PR DESCRIPTION
This change will bring support to run task_executor for Docker.

**Features:**

How to run a docker container 
```
$ git clone https://github.com/christianricci/task_executor.git
$ cd task_executor
$ cat Dockerfile

$ docker build .
$ docker tag <image_id> task-executor:latest # Get the id from the previous cmd output
$ docker run -d -i --name task_executor task-executor:latest

$ docker exec -ti task_executor python -m task_executor.shell_executor
$ docker exec -ti task_executor python -m task_executor.shell_executor create_executor_db
$ docker exec -ti task_executor python -m task_executor.shell_executor add_command my-tag '{"command": ["echo","\"Hello World!!!\""]}'
$ docker exec -ti task_executor python -m task_executor.shell_executor run_command my-tag 1 1
$ docker exec -ti task_executor cat /task_executor/shell-executor.debug.log
```
**Fixes:**

Disable max pool of connections in SqlAlchemy to avoid the error `sqlalchemy.exc.TimeoutError: QueuePool limit of size 5 overflow 20 reached, connection timed out, timeout 5.00 (Background on this error at: https://sqlalche.me/e/14/3o7r)`